### PR TITLE
fix: 타입 잘못 지정한 것 수정

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,7 +1,7 @@
 type User = {
-  name: String;
-  dailyCheckBools: Array<Boolean>;
-  dailyCheckCoins: Array<Number>;
+  name: string;
+  dailyCheckBools: Array<boolean>;
+  dailyCheckCoins: Array<number>;
 };
 
 export default User;


### PR DESCRIPTION
Number와 number, Boolean과 boolean 타입 차이
number와 boolean, string이 원시타입이므로 이로 수정
Number 및 Boolean은 다른 타입을 number와 boolean 타입으로 변경하기 위한 메소드를 지닌 객체로 number나 boolean같은 원시타입이 아니었음